### PR TITLE
docs: improve installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A collection of shared function for Jina Executor
 Add to your Executors `requirements.txt`
 
 ```text
-git+git://github.com/jina-ai/jina-commons
+git+https://github.com/jina-ai/jina-commons.git
 ```
 
 #### Import

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A collection of shared function for Jina Executor
 Add to your Executors `requirements.txt`
 
 ```text
-git+https://github.com/jina-ai/jina-commons.git
+git+https://github.com/jina-ai/jina-commons
 ```
 
 #### Import


### PR DESCRIPTION
This replaces `git+git` with the `git+https` installation instruction, as the use of `git+git` is [discouraged](https://pip.pypa.io/en/stable/cli/pip_install/#git).