### PR TITLE
fix: fix filtering by text attr in batch generator

### DIFF
--- a/jina_commons/batching.py
+++ b/jina_commons/batching.py
@@ -31,7 +31,7 @@ def get_docs_batch_generator(
     :param docs: A document array.
     :param traversal_path: Specifies along which "axis" the document shall be traversed. (defaults to ['r'])
     :param batch_size: Size of each generated batch (except the last one, which might be smaller, default: 32)
-    :param needs_attr: Optionally, you can filter out docs which don't have this content attribute. 
+    :param needs_attr: Optionally, you can filter out docs which don't have this content attribute
 
     :return: Generator
     """

--- a/jina_commons/batching.py
+++ b/jina_commons/batching.py
@@ -31,7 +31,7 @@ def get_docs_batch_generator(
     :param docs: A document array.
     :param traversal_path: Specifies along which "axis" the document shall be traversed. (defaults to ['r'])
     :param batch_size: Size of each generated batch (except the last one, which might be smaller, default: 32)
-    :param needs_attr: Optionally, you can filter out docs which don't have this attribute
+    :param needs_attr: Optionally, you can filter out docs which don't have this content attribute. 
 
     :return: Generator
     """
@@ -42,7 +42,7 @@ def get_docs_batch_generator(
     flat_docs = docs.traverse_flat(traversal_path)
     if needs_attr:
         # Text is equal to empty string (not None) by default
-        if needs_attr == 'text':
+        if needs_attr in ['text', 'uri', 'buffer']:
             flat_docs = [doc for doc in flat_docs if getattr(doc, needs_attr)]
         else:
             flat_docs = [

--- a/jina_commons/batching.py
+++ b/jina_commons/batching.py
@@ -31,7 +31,7 @@ def get_docs_batch_generator(
     :param docs: A document array.
     :param traversal_path: Specifies along which "axis" the document shall be traversed. (defaults to ['r'])
     :param batch_size: Size of each generated batch (except the last one, which might be smaller, default: 32)
-    :param needs_attr: Optionally, you can filter out docs which don't have this content attribute
+    :param needs_attr: Optionally, you can filter out docs which don't have this attribute
 
     :return: Generator
     """

--- a/jina_commons/batching.py
+++ b/jina_commons/batching.py
@@ -4,16 +4,18 @@ from typing import List, Generator, Optional
 from jina import DocumentArray
 
 
-def _batch_generator(data: DocumentArray, batch_size: int) -> Generator[DocumentArray, None, None]:
+def _batch_generator(
+    data: DocumentArray, batch_size: int
+) -> Generator[DocumentArray, None, None]:
     for i in range(0, len(data), batch_size):
-        yield data[i: i + batch_size]
+        yield data[i : i + batch_size]
 
 
 def get_docs_batch_generator(
     docs: Optional[DocumentArray] = None,
     traversal_path: List[str] = None,
     batch_size: int = 32,
-    needs_attr: Optional[str] = None
+    needs_attr: Optional[str] = None,
 ) -> Generator[DocumentArray, None, None]:
     """
     Creates a `Generator` that yields `DocumentArray` of size `batch_size` until `docs` is fully traversed along
@@ -39,7 +41,13 @@ def get_docs_batch_generator(
         docs = DocumentArray()
     flat_docs = docs.traverse_flat(traversal_path)
     if needs_attr:
-        flat_docs = [doc for doc in flat_docs if getattr(doc, needs_attr) is not None]
+        # Text is equal to empty string (not None) by default
+        if needs_attr == 'text':
+            flat_docs = [doc for doc in flat_docs if getattr(doc, needs_attr)]
+        else:
+            flat_docs = [
+                doc for doc in flat_docs if getattr(doc, needs_attr) is not None
+            ]
 
     filtered_docs = DocumentArray([doc for doc in flat_docs if doc is not None])
 

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -12,9 +12,7 @@ NUM_DOCS = 15
 
 @pytest.fixture()
 def doc_array() -> DocumentArray:
-    return DocumentArray([
-        Document(text='test') for _ in range(NUM_DOCS)
-    ])
+    return DocumentArray([Document(text='test') for _ in range(NUM_DOCS)])
 
 
 @pytest.fixture()
@@ -24,18 +22,12 @@ def docs_root(doc_array: DocumentArray) -> DocumentArray:
 
 @pytest.fixture()
 def docs_chunk(doc_array: DocumentArray) -> DocumentArray:
-    return DocumentArray([
-        Document(chunks=doc_array)
-    ])
+    return DocumentArray([Document(chunks=doc_array)])
 
 
 @pytest.fixture()
 def docs_chunk_chunk(doc_array) -> DocumentArray:
-    return DocumentArray([
-        Document(chunks=[
-            Document(chunks=doc_array)
-        ])
-    ])
+    return DocumentArray([Document(chunks=[Document(chunks=doc_array)])])
 
 
 @pytest.mark.parametrize(
@@ -46,46 +38,56 @@ def docs_chunk_chunk(doc_array) -> DocumentArray:
         (lazy_fixture('docs_root'), 5, 'text', [5, 5, 5], ['r']),
         (lazy_fixture('docs_root'), 5, 'text', [-1], ['c']),
         (lazy_fixture('docs_root'), 5, 'blob', [-1], ['r']),
-
         (lazy_fixture('docs_chunk'), 10, 'text', [10, 5], ['c']),
         (lazy_fixture('docs_chunk'), 20, 'text', [15], ['c']),
         (lazy_fixture('docs_chunk'), 5, 'text', [5, 5, 5], ['c']),
         (lazy_fixture('docs_chunk'), 5, 'text', [1], ['r']),
         (lazy_fixture('docs_chunk'), 5, 'blob', [-1], ['c']),
-
         (lazy_fixture('docs_chunk_chunk'), 10, 'text', [10, 5], ['cc']),
         (lazy_fixture('docs_chunk_chunk'), 20, 'text', [15], ['cc']),
         (lazy_fixture('docs_chunk_chunk'), 5, 'text', [5, 5, 5], ['cc']),
         (lazy_fixture('docs_chunk_chunk'), 5, 'text', [1], ['c']),
         (lazy_fixture('docs_chunk_chunk'), 5, 'blob', [-1], ['cc']),
-    ]
-
+    ],
 )
 def test_batching(
     docs: DocumentArray,
     batch_size: int,
     filter_attr: str,
     expected_sizes: List[int],
-    traversal_path: List[str]
+    traversal_path: List[str],
 ):
     generator = get_docs_batch_generator(
         docs,
         traversal_path=traversal_path,
         batch_size=batch_size,
-        needs_attr=filter_attr
+        needs_attr=filter_attr,
     )
     for batch, expected_size in zip(generator, expected_sizes):
-        assert len(batch) == expected_size, f'Expected size {expected_size} but got {len(batch)}'
+        assert (
+            len(batch) == expected_size
+        ), f'Expected size {expected_size} but got {len(batch)}'
 
 
 def test_docs_array_none():
     docs = None
-    generator = get_docs_batch_generator(
-        docs,
-        traversal_path=['r'],
-        batch_size=1
-    )
+    generator = get_docs_batch_generator(docs, traversal_path=['r'], batch_size=1)
     count = 0
     for count, item in enumerate(generator):
         pass
     assert count == 0
+
+
+def test_needs_text_empty():
+    """
+    Test the case where needs_attr='text', and empty documents are part of the array
+    """
+
+    docs = DocumentArray([Document(), Document(text='text')])
+    generator = get_docs_batch_generator(
+        docs, traversal_path=['r'], batch_size=1, needs_attr='text'
+    )
+    filtered_docs = list(generator)
+
+    assert len(filtered_docs) == 1 and len(filtered_docs[0]) == 1
+    assert filtered_docs[0][0].text == 'text'


### PR DESCRIPTION
This fixes the case when `needs_attr='text'` in `_batch_generator` - as the default value of the `text` attribute of a `Document` is `''` and not `None`, filtering would fail. I also format the two files I worked on with black.  