### PR TITLE
feat: logging decorator for executors

### DIFF
--- a/jina_commons/logging.py
+++ b/jina_commons/logging.py
@@ -1,0 +1,59 @@
+import os
+import time
+from typing import List
+
+from jina import DocumentArray
+from jina.logging.logger import JinaLogger
+
+
+def _get_non_empty_fields_doc_array(docs: DocumentArray) -> List[str]:
+    non_empty_fields = list(docs[0].non_empty_fields)
+    for doc in docs[:1]:
+        for field in non_empty_fields:
+            if field not in doc.non_empty_fields:
+                non_empty_fields.pop(field)
+    return non_empty_fields
+
+
+def add_request_logger(logger):
+    """
+    Add logging functionality to a request function.
+    Only shows logs for `JINA_LOG_LEVEL` > info.
+    You can set this as an env variable before starting your `Jina` application.
+
+    Example usages:
+    >>> from jina import Executor, requests
+    >>> my_logger = JinaLogger('MyExecLogger')
+    >>>
+    >>> class MyExec(Executor):
+    >>>     @requests
+    >>>     @add_request_logger(my_logger)
+    >>>     def index(self, docs, parameters, **kwargs):
+    >>>          ...
+
+    :param logger: The logger you want to use
+    """
+    def decorator(function):
+        def wrapper(self, docs, parameters, **kwargs):
+
+            if os.environ.get('JINA_LOG_LEVEL') in ['info', None]:
+                return function(self, docs, parameters, **kwargs)
+            if not docs:
+                logger.info('Docs is None. Nothing to monitor')
+                return function(self, docs, parameters, **kwargs)
+
+            logger.info(f'📄 Received request containing {len(docs)} documents.')
+            logger.info(f'📕 Received parameters dictionary: {parameters}')
+
+            if len(docs) > 0:
+                non_empty_fields = _get_non_empty_fields_doc_array(docs)
+                logger.info(f'🏷 Non-empty fields {non_empty_fields}')
+
+            start_time = time.time()
+            result = function(self, docs, parameters, **kwargs)
+            end_time = time.time()
+            logger.info(f'⏱ Elapsed time for request {end_time - start_time} seconds.')
+            return result
+
+        return wrapper
+    return decorator

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -3,7 +3,6 @@ import os
 
 import pytest
 from jina import DocumentArray, Document
-from jina.logging.logger import JinaLogger
 
 from jina_commons.logging import add_request_logger
 
@@ -12,7 +11,7 @@ class MockLogger:
     def __init__(self):
         self.logs = []
 
-    def info(self, msg: str):
+    def debug(self, msg: str):
         self.logs.append(msg)
 
 
@@ -57,27 +56,3 @@ def test_request_logger_recognizes_log_level(document_array: DocumentArray):
     executor.index(document_array, parameters={})
 
     assert len(logger.logs) == 0
-
-
-@pytest.mark.parametrize(
-    ['log_level', 'output_expected'],
-    [
-        ('debug', True),
-        ('info', False),
-        ('error', True)
-    ]
-)
-def test_logs_are_streamed_to_std_out_depends_on_level(log_level: str, output_expected: bool, document_array: DocumentArray, capsys):
-    logger = JinaLogger('test')
-    os.environ['JINA_LOG_LEVEL'] = log_level
-
-    class MyExec:
-        @add_request_logger(logger=logger)
-        def index(self, docs, parameters, **kwargs):
-            pass
-
-    MyExec().index(document_array, parameters={})
-
-    captured = capsys.readouterr()
-    assert (len(captured.out) > 0) == output_expected
-    os.environ.pop('JINA_LOG_LEVEL')

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,83 @@
+# Test suite for the logging.py module
+import os
+
+import pytest
+from jina import DocumentArray, Document
+from jina.logging.logger import JinaLogger
+
+from jina_commons.logging import add_request_logger
+
+
+class MockLogger:
+    def __init__(self):
+        self.logs = []
+
+    def info(self, msg: str):
+        self.logs.append(msg)
+
+
+@pytest.fixture
+def document_array() -> DocumentArray:
+    return DocumentArray(
+        [
+            Document(text='test'),
+            Document(text='test'),
+            Document(text='test')
+        ]
+    )
+
+
+def test_request_logger(document_array: DocumentArray):
+    logger = MockLogger()
+    os.environ['JINA_LOG_LEVEL'] = 'debug'
+
+    class MyExec:
+        @add_request_logger(logger=logger)
+        def index(self, docs, parameters, **kwargs):
+            pass
+
+    executor = MyExec()
+
+    executor.index(docs=document_array, parameters={'top_k': 3})
+
+    assert len(logger.logs) == 4
+    os.environ.pop('JINA_LOG_LEVEL')
+
+
+def test_request_logger_recognizes_log_level(document_array: DocumentArray):
+    logger = MockLogger()
+
+    class MyExec:
+        @add_request_logger(logger=logger)
+        def index(self, docs, parameters, **kwargs):
+            pass
+
+    executor = MyExec()
+
+    executor.index(document_array, parameters={})
+
+    assert len(logger.logs) == 0
+
+
+@pytest.mark.parametrize(
+    ['log_level', 'output_expected'],
+    [
+        ('debug', True),
+        ('info', False),
+        ('error', True)
+    ]
+)
+def test_logs_are_streamed_to_std_out_depends_on_level(log_level: str, output_expected: bool, document_array: DocumentArray, capsys):
+    logger = JinaLogger('test')
+    os.environ['JINA_LOG_LEVEL'] = log_level
+
+    class MyExec:
+        @add_request_logger(logger=logger)
+        def index(self, docs, parameters, **kwargs):
+            pass
+
+    MyExec().index(document_array, parameters={})
+
+    captured = capsys.readouterr()
+    assert (len(captured.out) > 0) == output_expected
+    os.environ.pop('JINA_LOG_LEVEL')


### PR DESCRIPTION
As user, I want to easily view logs about the received documents, parameters and execution time of my executor.

This PR adds a decorator to the jina-commons which can be attached to executor classes.
It adds no configuration overhead because it listens on the `JINA_LOG_LEVEL`.

Example usage

```
>>> from jina import Executor, requests
>>> my_logger = JinaLogger('MyExecLogger')
>>>
>>> class MyExec(Executor):
>>>     @requests
>>>     @add_request_logger(my_logger)
>>>     def index(self, docs, parameters, **kwargs):
>>>          ...
```

Example Output

```
test@31386[I]:📄 Received request containing 3 documents.
test@31386[I]:📕 Received parameters dictionary: {}
test@31386[I]:✏️ Non-empty fields ['id', 'mime_type', 'text', 'content_hash']
test@31386[I]:⏱ Elapsed time for request 9.5367431640625e-07 seconds.
```